### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/snake_game.yml
+++ b/.github/workflows/snake_game.yml
@@ -1,5 +1,8 @@
 name: Generate Snake Game
 
+permissions:
+  contents: write
+
 # Controls when the workflow will run
 on:
   # Schedules the workflow to run every 5 minutes (minimum supported by GitHub Actions)


### PR DESCRIPTION
Potential fix for [https://github.com/sinwulok/sinwulok/security/code-scanning/1](https://github.com/sinwulok/sinwulok/security/code-scanning/1)

In general, fix this by explicitly defining a `permissions` section for the workflow or for the individual job, granting only the minimal scopes required. For this workflow, the job must be able to push commits to the repository, so it needs `contents: write`; there is no indication it needs additional scopes such as `issues`, `pull-requests`, or `packages`, so those should not be granted.

The best fix with no behavior change is to add a top-level `permissions` block (applies to all jobs) just below the `name:` or `on:` section, specifying `contents: write`. This preserves the ability for `EndBug/add-and-commit` to commit and push to the `widgets-snake` branch (which uses the `GITHUB_TOKEN`) while restricting the token from having broader write access to other resources. No imports or additional methods are needed, as this is purely a YAML configuration change in `.github/workflows/snake_game.yml`.

Concretely, in `.github/workflows/snake_game.yml`, insert:

```yaml
permissions:
  contents: write
```

near the top-level of the file (e.g., after `name: Generate Snake Game` and before `on:`). This will satisfy CodeQL’s requirement for explicit permissions while maintaining existing functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
